### PR TITLE
Implemented auto scan for libraries

### DIFF
--- a/CMakeFindPackage.tx
+++ b/CMakeFindPackage.tx
@@ -1,0 +1,6 @@
+FIND_PACKAGE([%package%] REQUIRED)
+IF ([%package%]_FOUND)
+    INCLUDE_DIRECTORIES(${[%package%]_INCLUDE_DIR})
+    ADD_DEFINITIONS( "-DHAS_[%package_upcase%]" )
+ENDIF()
+    


### PR DESCRIPTION
Implemented https://github.com/envi/vcxproj2cmake/issues/6 "Implement auto scan for libraries"
Implemented for boost, SDL, OpenSSL and ZLIB.
Other packages could be simply added by uncommenting proper line and adding appropriate include pattern.
